### PR TITLE
Fix logging and add support to pass seed from outside of TCP Proxy

### DIFF
--- a/failuregen/failure_generator.go
+++ b/failuregen/failure_generator.go
@@ -46,11 +46,17 @@ type FailureGeneratorImpl struct {
 	randGen        *randutil.LockedRandGen
 }
 
-// NewFailureGenerator creates a new failure-generator
+// NewFailureGenerator creates a new failure-generator with a default seed
 func NewFailureGenerator() FailureGenerator {
+	return NewFailureGeneratorWithSeed(time.Now().UnixNano())
+}
+
+// NewFailureGeneratorWithSeed creates a new failure-generator with the given
+// seed
+func NewFailureGeneratorWithSeed(seed int64) FailureGenerator {
 	return &FailureGeneratorImpl{
 		DelayFn: time.Sleep,
-		randGen: randutil.NewLockedRandGen(time.Now().Unix()),
+		randGen: randutil.NewLockedRandGen(seed),
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -40,6 +40,8 @@ type Logger interface {
 	FatalfDepth(ctx context.Context, depth int, format string, args ...interface{})
 	// V returns whether the given verbosity should be logged
 	V(level int32) bool
+	// SetLogLevel sets the log level
+	SetLogLevel(level int32)
 	// WithLogTag returns a context with a log tag
 	WithLogTag(ctx context.Context, name string, value interface{}) context.Context
 	// Flush the logger
@@ -116,6 +118,10 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 // V returns whether the given verbosity should be logged
 func V(level int32) bool {
 	return logger.l.V(level)
+}
+
+func SetLogLevel(level int32) {
+	logger.l.SetLogLevel(level)
 }
 
 // WithLogTag returns a context with a log tag

--- a/log/simple_logger.go
+++ b/log/simple_logger.go
@@ -70,8 +70,11 @@ func (s *simpleLogger) FatalfDepth(ctx context.Context, depth int, format string
 }
 
 func (s *simpleLogger) V(level int32) bool {
-	log.SetLevel(log.TraceLevel)
-	return true
+	return log.IsLevelEnabled(log.Level(level))
+}
+
+func (s *simpleLogger) SetLogLevel(level int32) {
+	log.SetLevel(log.Level(level))
 }
 
 func (s *simpleLogger) WithLogTag(ctx context.Context, name string, value interface{}) context.Context {


### PR DESCRIPTION
## Summary:
This diff does the following -
1. Fixes log.V() to not always return true.
2. Adds support to set log level from outside of TCP Proxy.
3. Adds support to pass seed from outside of TCP Proxy.

## JIRA Issues:
[CDM-504205](https://rubrik.atlassian.net/browse/CDM-504205?atlOrigin=eyJpIjoiNDg4Njc5MDY2OTFhNDQyNDk1MzUyMGNmYjE0YWYzZmIiLCJwIjoiaiJ9)